### PR TITLE
Add Package archive

### DIFF
--- a/njs-archive/archive.go
+++ b/njs-archive/archive.go
@@ -1,0 +1,92 @@
+/*
+ *  MIT License
+ *
+ *  Copyright (c) 2020 Nicolas JUHEL
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+package njs_archive
+
+import (
+	"os"
+
+	"github.com/nabbar/golib/njs-archive/bz2"
+	"github.com/nabbar/golib/njs-archive/gzip"
+	"github.com/nabbar/golib/njs-archive/tar"
+	"github.com/nabbar/golib/njs-archive/zip"
+
+	//. "github.com/nabbar/golib/njs-logger"
+
+	iou "github.com/nabbar/golib/njs-ioutils"
+)
+
+type ArchiveType uint8
+
+func ExtractFile(src *os.File, fileNameContain, fileNameRegex string) (*os.File, error) {
+	var err error
+
+	loc := src.Name()
+
+	if dst, err := bz2.GetFile(src, fileNameContain, fileNameRegex); err == nil {
+		//DebugLevel.Log("try deleting source archive...")
+		if err = iou.DelTempFile(src, true); err != nil {
+			return nil, err
+		}
+		//DebugLevel.Log("try another archive...")
+		return ExtractFile(dst, fileNameContain, fileNameRegex)
+	}
+
+	if dst, err := gzip.GetFile(src, fileNameContain, fileNameRegex); err == nil {
+		//DebugLevel.Log("try deleting source archive...")
+		if err = iou.DelTempFile(src, true); err != nil {
+			return nil, err
+		}
+		//DebugLevel.Log("try another archive...")
+		return ExtractFile(dst, fileNameContain, fileNameRegex)
+	}
+
+	if dst, err := tar.GetFile(src, fileNameContain, fileNameRegex); err == nil {
+		//DebugLevel.Log("try deleting source archive...")
+		if err = iou.DelTempFile(src, true); err != nil {
+			return nil, err
+		}
+		//DebugLevel.Log("try another archive...")
+		return ExtractFile(dst, fileNameContain, fileNameRegex)
+	}
+
+	if dst, err := zip.GetFile(src, fileNameContain, fileNameRegex); err == nil {
+		//DebugLevel.Log("try deleting source archive...")
+		if err = iou.DelTempFile(src, true); err != nil {
+			return nil, err
+		}
+		//DebugLevel.Log("try another archive...")
+		return ExtractFile(dst, fileNameContain, fileNameRegex)
+	}
+
+	if _, err = src.Seek(0, 0); err != nil {
+		if src, err = os.Open(loc); err != nil {
+			//ErrorLevel.LogErrorCtx(DebugLevel, "reopening file", err)
+			return nil, err
+		}
+	}
+
+	return src, nil
+}

--- a/njs-archive/archive/model.go
+++ b/njs-archive/archive/model.go
@@ -1,0 +1,94 @@
+/*
+ *  MIT License
+ *
+ *  Copyright (c) 2020 Nicolas JUHEL
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+package archive
+
+import (
+	"path"
+	"regexp"
+	"strings"
+)
+
+type File struct {
+	Name string
+	Path string
+}
+
+func (a File) Matching(containt string) bool {
+	if len(containt) < 1 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(a.Name), strings.ToLower(containt))
+}
+
+func (a File) Regex(regex string) bool {
+	if len(regex) < 1 {
+		return false
+	}
+
+	b, _ := regexp.MatchString(regex, a.Name)
+
+	return b
+}
+
+func (a File) MatchingFullPath(containt string) bool {
+	if len(containt) < 1 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(a.GetKeyMap()), strings.ToLower(containt))
+}
+
+func (a File) RegexFullPath(regex string) bool {
+	if len(regex) < 1 {
+		return false
+	}
+
+	b, _ := regexp.MatchString(regex, a.GetKeyMap())
+
+	return b
+}
+
+func (a File) GetKeyMap() string {
+	return path.Join(a.Path, a.Name)
+}
+
+func (a File) GetDestFileOnly(baseDestination string) string {
+	return path.Join(baseDestination, a.Name)
+}
+
+func (a File) GetDestWithPath(baseDestination string) string {
+	return path.Join(baseDestination, a.Path, a.Name)
+}
+
+func NewFile(name, path string) File {
+	return File{
+		Name: name,
+		Path: path,
+	}
+}
+
+func NewFileFullPath(fullpath string) File {
+	return NewFile(path.Base(fullpath), path.Dir(fullpath))
+}

--- a/njs-archive/bz2/reader.go
+++ b/njs-archive/bz2/reader.go
@@ -1,0 +1,58 @@
+/*
+ *  MIT License
+ *
+ *  Copyright (c) 2020 Nicolas JUHEL
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+package bz2
+
+import (
+	"compress/bzip2"
+	"io"
+	"os"
+
+	//. "github.com/nabbar/golib/njs-logger"
+
+	iou "github.com/nabbar/golib/njs-ioutils"
+)
+
+func GetFile(src *os.File, filenameContain, filenameRegex string) (dst *os.File, err error) {
+	if _, e := src.Seek(0, 0); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "seeking buffer", e)
+		return nil, e
+	}
+
+	r := bzip2.NewReader(src)
+
+	if t, e := iou.NewTempFile(); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "init new temporary buffer", e)
+		return nil, e
+	} else if _, e = io.Copy(t, r); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "copy buffer from archive reader", e)
+		return nil, e
+	} else if _, e = t.Seek(0, 0); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "seeking temp file", e)
+		return nil, e
+	} else {
+		return t, nil
+	}
+}

--- a/njs-archive/gzip/reader.go
+++ b/njs-archive/gzip/reader.go
@@ -1,0 +1,64 @@
+/*
+ *  MIT License
+ *
+ *  Copyright (c) 2020 Nicolas JUHEL
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+package gzip
+
+import (
+	gz "compress/gzip"
+	"io"
+	"os"
+
+	//. "github.com/nabbar/golib/njs-logger"
+
+	iou "github.com/nabbar/golib/njs-ioutils"
+)
+
+func GetFile(src *os.File, filenameContain, filenameRegex string) (dst *os.File, err error) {
+	if _, e := src.Seek(0, 0); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "seeking buffer", e)
+		return nil, e
+	}
+
+	r, e := gz.NewReader(src)
+	if e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "init gzip reader", e)
+		return nil, e
+	}
+
+	defer r.Close()
+
+	if t, e := iou.NewTempFile(); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "init new temporary buffer", e)
+		return nil, e
+	} else if _, e = io.Copy(t, r); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "copy buffer from archive reader", e)
+		return nil, e
+	} else if _, e = t.Seek(0, 0); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "seeking temp file", e)
+		return nil, e
+	} else {
+		return t, nil
+	}
+}

--- a/njs-archive/tar/reader.go
+++ b/njs-archive/tar/reader.go
@@ -1,0 +1,78 @@
+/*
+ *  MIT License
+ *
+ *  Copyright (c) 2020 Nicolas JUHEL
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+package tar
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+
+	"github.com/nabbar/golib/njs-archive/archive"
+
+	//. "github.com/nabbar/golib/njs-logger"
+
+	iou "github.com/nabbar/golib/njs-ioutils"
+)
+
+func GetFile(src *os.File, filenameContain, filenameRegex string) (dst *os.File, err error) {
+	if _, e := src.Seek(0, 0); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "seeking buffer", e)
+		return nil, e
+	}
+
+	r := tar.NewReader(src)
+
+	for {
+		h, e := r.Next()
+
+		if e != nil && e == io.EOF {
+			return nil, nil
+		} else if e != nil {
+			//ErrorLevel.LogErrorCtx(DebugLevel, "trying to read next file", e)
+			return nil, e
+		}
+
+		if h.FileInfo().Mode()&os.ModeType == os.ModeType {
+			continue
+		}
+
+		f := archive.NewFileFullPath(h.Name)
+		if f.MatchingFullPath(filenameContain) || f.RegexFullPath(filenameRegex) {
+			if t, e := iou.NewTempFile(); e != nil {
+				//ErrorLevel.LogErrorCtx(DebugLevel, "init new temporary buffer", e)
+				return nil, e
+			} else if _, e = io.Copy(t, r); e != nil {
+				//ErrorLevel.LogErrorCtx(DebugLevel, "copy buffer from archive reader", e)
+				return nil, e
+			} else if _, e = t.Seek(0, 0); e != nil {
+				//ErrorLevel.LogErrorCtx(DebugLevel, "seeking temp file", e)
+				return nil, e
+			} else {
+				return t, nil
+			}
+		}
+	}
+}

--- a/njs-archive/zip/reader.go
+++ b/njs-archive/zip/reader.go
@@ -1,0 +1,99 @@
+/*
+ *  MIT License
+ *
+ *  Copyright (c) 2020 Nicolas JUHEL
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+package zip
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+
+	//. "github.com/nabbar/golib/njs-logger"
+
+	iou "github.com/nabbar/golib/njs-ioutils"
+
+	"github.com/nabbar/golib/njs-archive/archive"
+)
+
+func GetFile(src *os.File, filenameContain, filenameRegex string) (dst *os.File, err error) {
+	location := iou.GetTempFilePath(src)
+
+	if err = src.Close(); err != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "trying to close temp file", err)
+		return
+	}
+
+	return getFile(location, filenameContain, filenameRegex)
+}
+
+func getFile(src string, filenameContain, filenameRegex string) (dst *os.File, err error) {
+	var (
+		r *zip.ReadCloser
+		e error
+	)
+
+	if r, e = zip.OpenReader(src); e != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "trying to open zip file", e)
+		return nil, e
+	}
+
+	defer r.Close()
+
+	for _, f := range r.File {
+		if f.Mode()&os.ModeType == os.ModeType {
+			continue
+		}
+
+		z := archive.NewFileFullPath(f.Name)
+		if z.MatchingFullPath(filenameContain) || z.RegexFullPath(filenameRegex) {
+			return extratFile(f)
+		}
+	}
+
+	return nil, nil
+}
+
+func extratFile(f *zip.File) (dst *os.File, err error) {
+	var r io.ReadCloser
+
+	if r, err = f.Open(); err != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "open zipped file reader", err)
+		return
+	}
+
+	defer r.Close()
+
+	if dst, err = iou.NewTempFile(); err != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "init new temporary buffer", err)
+		return
+	} else if _, err = io.Copy(dst, r); err != nil {
+		//ErrorLevel.LogErrorCtx(DebugLevel, "copy buffer from archive reader", err)
+		return
+	}
+
+	_, err = dst.Seek(0, 0)
+	//ErrorLevel.LogErrorCtx(DebugLevel, "seeking temp file", err)
+	return
+}

--- a/njs-ioutils/tempFile.go
+++ b/njs-ioutils/tempFile.go
@@ -1,0 +1,71 @@
+/*
+ *  MIT License
+ *
+ *  Copyright (c) 2020 Nicolas JUHEL
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+package njs_ioutils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+func NewTempFile() (*os.File, error) {
+	if f, e := ioutil.TempFile(os.TempDir(), ""); e != nil {
+		return nil, e
+	} else {
+		return f, nil
+	}
+}
+
+func GetTempFilePath(f *os.File) string {
+	if f == nil {
+		return ""
+	}
+
+	return path.Join(os.TempDir(), path.Base(f.Name()))
+}
+
+func DelTempFile(f *os.File, ignoreErrClose bool) error {
+	if f == nil {
+		return nil
+	}
+
+	n := GetTempFilePath(f)
+	a := f.Close()
+	b := os.Remove(n)
+
+	if ignoreErrClose {
+		return b
+	}
+
+	if a != nil && b != nil {
+		return fmt.Errorf("%v, %v", a, b)
+	} else if a != nil {
+		return a
+	}
+
+	return b
+}

--- a/test/test-archive/main.go
+++ b/test/test-archive/main.go
@@ -1,0 +1,87 @@
+/*
+ *  MIT License
+ *
+ *  Copyright (c) 2020 Nicolas JUHEL
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ */
+
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+
+	njs_archive "github.com/nabbar/golib/njs-archive"
+
+	iou "github.com/nabbar/golib/njs-ioutils"
+)
+
+// git archive --format=tar --output=git.tar HEAD
+//const fileName = "./git.tar"
+const fileName = "./vendor.zip"
+
+//const contain = "njs-version/license_mit.go"
+const contain = "vendor/github.com/gin-gonic/gin/internal/json/json.go"
+
+//const regex = ""
+const regex = "vendor\\.tar(\\.(?:gz|bz))?"
+
+func main() {
+	var (
+		src *os.File
+		tmp *os.File
+		rio *os.File
+		err error
+	)
+
+	if src, err = os.Open(fileName); err != nil {
+		panic(err)
+	}
+
+	defer src.Close()
+
+	if tmp, err = iou.NewTempFile(); err != nil {
+		panic(err)
+	}
+
+	defer iou.DelTempFile(tmp, true)
+
+	if _, err = io.Copy(tmp, src); err != nil {
+		panic(err)
+	}
+
+	if rio, err = njs_archive.ExtractFile(tmp, contain, regex); err != nil {
+		panic(err)
+	}
+
+	defer rio.Close()
+
+	if _, err = rio.Seek(0, 0); err != nil {
+		panic(err)
+	}
+
+	if b, e := ioutil.ReadAll(rio); e != nil {
+		panic(e)
+	} else {
+		println(string(b))
+	}
+}

--- a/test/test-archive/make_test.sh
+++ b/test/test-archive/make_test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+[ ! -e vendor.tar.gz ] || rm -v vendor.tar.gz
+[ ! -e vendor.tar.bz2 ] || rm -v vendor.tar.bz2
+[ ! -e vendor.zip ] || rm -v vendor.zip
+[ ! -e ph-000.tar ] || rm -v ph-00*.tar
+[ ! -e test-archive ] || rm -v test-archive
+
+tar cf ph-000.tar vendor/ && \
+cp -v ph-000.tar ph-001.tar && \
+cp -v ph-000.tar ph-002.tar && \
+cp -v ph-000.tar ph-003.tar && \
+cp -v ph-000.tar ph-004.tar && \
+cp -v ph-000.tar ph-005.tar && \
+cp -v ph-000.tar ph-006.tar && \
+cp -v ph-000.tar ph-007.tar && \
+cp -v ph-000.tar ph-008.tar && \
+cp -v ph-000.tar ph-009.tar && \
+tar czf vendor.tar.gz vendor/ && \
+tar cjf vendor.tar.bz2 ph-00*.tar vendor.tar.gz && \
+zip vendor.zip ph-00*.tar vendor.tar.bz2 && \
+rm -vf ph-00*.tar vendor.tar.* && \
+ls -ahl vendor.zip && \
+go build -a -v -o test-archive ./test/test-archive/ && \
+echo -e "\n\n\t>>Try to print contents of file github.com/gin-gonic/gin/internal/json/json.go" && \
+./test-archive
+echo -e "\n\n\t>>from archive zip >> bz2 >> tar >> gz >> tar :" && \
+ls -ahl vendor.zip && \
+echo -e "\n\n"
+
+[ ! -e vendor.tar.gz ] || rm -v vendor.tar.gz
+[ ! -e vendor.tar.bz2 ] || rm -v vendor.tar.bz2
+[ ! -e vendor.zip ] || rm -v vendor.zip
+[ ! -e ph-000.tar ] || rm -v ph-00*.tar
+[ ! -e test-archive ] || rm -v test-archive


### PR DESCRIPTION
# Add Package Archive : 
- func ExtractFile : recursive func to extract from any (zip, tar, bz2, gzip) archive/compressed file
- allow to push multiple compressed file, search for included file
- search based on included full path name and substrings pattern or regex matching
- return an os file pointer to temporary file

# Add I/O Functions for temporary file : 
- func NewTempFile to return an os Temp File pointer
- func GeTempFilePath to return the current full path of the given os Temp File pointer
- func DelTempFile to clean the given os Temp File pointer

# a test / example file for Archive Package : 
- add a to test to print content of a go file in vendor folder from a zip => bz2 => tar => gzip => tar => vendor/.../file to print
- add a shell script to create an the example archive zip 
