### PR TITLE
Fix logger GetFrame

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -124,7 +124,7 @@ func EnableViperLog(enable bool) {
 
 func getFrame() runtime.Frame {
 	// Set size to targetFrameIndex+2 to ensure we have room for one more caller than we need
-	programCounters := make([]uintptr, 10)
+	programCounters := make([]uintptr, 10, 255)
 	n := runtime.Callers(1, programCounters)
 
 	if n > 0 {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -124,8 +124,8 @@ func EnableViperLog(enable bool) {
 
 func getFrame() runtime.Frame {
 	// Set size to targetFrameIndex+2 to ensure we have room for one more caller than we need
-	programCounters := make([]uintptr, 0)
-	n := runtime.Callers(0, programCounters)
+	programCounters := make([]uintptr, 10)
+	n := runtime.Callers(1, programCounters)
 
 	if n > 0 {
 		frames := runtime.CallersFrames(programCounters[:n])


### PR DESCRIPTION
runtime.Callers now fill in the slice the last 10 callers and skips the first one (runtime.Callers).