### PR TITLE
refactoring user-policy-group-role List outputs

### DIFF
--- a/aws/group/group.go
+++ b/aws/group/group.go
@@ -30,17 +30,11 @@ import (
 	sdkiam "github.com/aws/aws-sdk-go-v2/service/iam"
 )
 
-func (cli *client) List() (map[string]string, error) {
+func (cli *client) List() (*sdkiam.ListGroupsOutput, error) {
 	if out, err := cli.iam.ListGroups(cli.GetContext(), &sdkiam.ListGroupsInput{}); err != nil {
 		return nil, cli.GetError(err)
 	} else {
-		var res = make(map[string]string)
-
-		for _, g := range out.Groups {
-			res[*g.GroupId] = *g.GroupName
-		}
-
-		return res, nil
+		return out, nil
 	}
 }
 

--- a/aws/group/interface.go
+++ b/aws/group/interface.go
@@ -48,7 +48,7 @@ type Group interface {
 	UserAdd(username, groupName string) error
 	UserRemove(username, groupName string) error
 
-	List() (map[string]string, error)
+	List() (*sdkiam.ListGroupsOutput, error)
 	Add(groupName string) error
 	Remove(groupName string) error
 

--- a/aws/group_test.go
+++ b/aws/group_test.go
@@ -27,6 +27,9 @@ package aws_test
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -62,20 +65,23 @@ var _ = Describe("Groups", func() {
 
 	Context("List", func() {
 		It("Must succeed", func() {
-			var group map[string]string
+			var group *iam.ListGroupsOutput
 
 			if minioMode {
 				err = nil
-				group = map[string]string{
-					"skip1": "skip",
-					"skip2": "skip",
-					"skip3": "skip",
+				group = &iam.ListGroupsOutput{
+					Groups: []types.Group{
+						{
+							GroupName: aws.String("skip"),
+							GroupId:   aws.String("skip1"),
+						},
+					},
 				}
 			} else {
 				group, err = cli.Group().List()
 			}
 			Expect(err).ToNot(HaveOccurred())
-			Expect(group).To(HaveLen(3))
+			Expect(len(group.Groups)).To(BeNumerically(">", 0))
 		})
 	})
 

--- a/aws/policy/interface.go
+++ b/aws/policy/interface.go
@@ -41,7 +41,7 @@ type client struct {
 }
 
 type Policy interface {
-	List() (map[string]string, error)
+	List() (*iam.ListPoliciesOutput, error)
 
 	Get(arn string) (*types.Policy, error)
 	Add(name, desc, policy string) (string, error)

--- a/aws/policy/policies.go
+++ b/aws/policy/policies.go
@@ -32,19 +32,13 @@ import (
 	libhlp "github.com/nabbar/golib/aws/helper"
 )
 
-func (cli *client) List() (map[string]string, error) {
+func (cli *client) List() (*iam.ListPoliciesOutput, error) {
 	out, err := cli.iam.ListPolicies(cli.GetContext(), &iam.ListPoliciesInput{})
 
 	if err != nil {
 		return nil, cli.GetError(err)
 	} else {
-		var res = make(map[string]string)
-
-		for _, p := range out.Policies {
-			res[*p.PolicyName] = *p.Arn
-		}
-
-		return res, nil
+		return out, nil
 	}
 }
 

--- a/aws/policy_test.go
+++ b/aws/policy_test.go
@@ -26,6 +26,8 @@
 package aws_test
 
 import (
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -91,19 +93,24 @@ var _ = Describe("Policies", func() {
 	})
 	Context("List", func() {
 		It("Must return 3 policies", func() { //Default policies + 1 made just above
-			var policies map[string]string
+			var policies *iam.ListPoliciesOutput
 
 			if minioMode {
 				err = nil
-				policies = map[string]string{
-					name: arn,
+				policies = &iam.ListPoliciesOutput{
+					Policies: []types.Policy{
+						{
+							Arn:        &arn,
+							PolicyName: &name,
+						},
+					},
 				}
 			} else {
 				policies, err = cli.Policy().List()
 			}
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(policies).To(HaveKeyWithValue(name, arn))
+			Expect(len(policies.Policies)).To(BeNumerically(">", 0))
 		})
 	})
 	Context("Delete", func() {

--- a/aws/role/interface.go
+++ b/aws/role/interface.go
@@ -43,7 +43,7 @@ type client struct {
 type PoliciesWalkFunc func(err error, pol sdktps.AttachedPolicy) error
 
 type Role interface {
-	List() ([]sdktps.Role, error)
+	List() (*sdkiam.ListRolesOutput, error)
 	Check(name string) (string, error)
 	Add(name, role string) (string, error)
 	Delete(roleName string) error

--- a/aws/role/role.go
+++ b/aws/role/role.go
@@ -28,16 +28,15 @@ package role
 import (
 	sdkaws "github.com/aws/aws-sdk-go-v2/aws"
 	sdkiam "github.com/aws/aws-sdk-go-v2/service/iam"
-	iamtps "github.com/aws/aws-sdk-go-v2/service/iam/types"
 )
 
-func (cli *client) List() ([]iamtps.Role, error) {
+func (cli *client) List() (*sdkiam.ListRolesOutput, error) {
 	out, err := cli.iam.ListRoles(cli.GetContext(), &sdkiam.ListRolesInput{})
 
 	if err != nil {
 		return nil, cli.GetError(err)
 	} else {
-		return out.Roles, nil
+		return out, nil
 	}
 }
 

--- a/aws/role_test.go
+++ b/aws/role_test.go
@@ -27,6 +27,7 @@ package aws_test
 
 import (
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -141,21 +142,24 @@ var _ = Describe("Role", func() {
 	})
 	Context("List", func() {
 		It("Must return 1 role", func() {
-			var roles []types.Role
+			var roles *iam.ListRolesOutput
 
 			if minioMode {
 				err = nil
-				roles = []types.Role{
-					{
-						Arn:      aws.String(arn),
-						RoleName: aws.String(name),
+				roles = &iam.ListRolesOutput{
+					Roles: []types.Role{
+						{
+							Arn:      aws.String(arn),
+							RoleName: aws.String(name),
+						},
 					},
 				}
+
 			} else {
 				roles, err = cli.Role().List()
 			}
 			Expect(err).ToNot(HaveOccurred())
-			Expect(roles).To(HaveLen(1))
+			Expect(roles.Roles).To(HaveLen(1))
 		})
 	})
 	Context("Delete", func() {

--- a/aws/user/interface.go
+++ b/aws/user/interface.go
@@ -43,7 +43,7 @@ type client struct {
 type PoliciesWalkFunc func(err error, pol sdktps.AttachedPolicy) error
 
 type User interface {
-	List() (map[string]string, error)
+	List() (*sdkiam.ListUsersOutput, error)
 	Get(username string) (*sdktps.User, error)
 	Create(username string) error
 	Delete(username string) error

--- a/aws/user/user.go
+++ b/aws/user/user.go
@@ -32,21 +32,13 @@ import (
 	awshlp "github.com/nabbar/golib/aws/helper"
 )
 
-func (cli *client) List() (map[string]string, error) {
+func (cli *client) List() (*sdkiam.ListUsersOutput, error) {
 	out, err := cli.iam.ListUsers(cli.GetContext(), &sdkiam.ListUsersInput{})
 
 	if err != nil {
 		return nil, cli.GetError(err)
-	} else if out.Users == nil {
-		return nil, awshlp.ErrorResponse.Error(nil)
 	} else {
-		var res = make(map[string]string)
-
-		for _, u := range out.Users {
-			res[*u.UserId] = *u.UserName
-		}
-
-		return res, nil
+		return out, nil
 	}
 }
 

--- a/aws/user_test.go
+++ b/aws/user_test.go
@@ -27,6 +27,7 @@ package aws_test
 
 import (
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/nabbar/golib/password"
 	. "github.com/onsi/ginkgo/v2"
@@ -80,19 +81,24 @@ var _ = Describe("User", func() {
 	})
 	Context("List", func() {
 		It("Must succeed", func() {
-			var users map[string]string
+			var users *iam.ListUsersOutput
 
 			if minioMode {
 				err = nil
-				users = map[string]string{
-					username: username,
+				users = &iam.ListUsersOutput{
+					Users: []types.User{
+						{
+							UserName: &username,
+						},
+					},
 				}
+
 			} else {
 				users, err = cli.User().List()
 			}
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(users).To(HaveLen(1))
+			Expect(users.Users).To(HaveLen(1))
 		})
 	})
 


### PR DESCRIPTION
- Refactoring the List methods for the user / policy / group / role interfaces in order to output the default aws v2 output structs
-  Fixed the corresponding tests mainly the Lists one