### PR TITLE
Refactoring aws

### DIFF
--- a/aws/group/group.go
+++ b/aws/group/group.go
@@ -54,8 +54,9 @@ func (cli *client) Walk(prefix string, fct GroupFunc) error {
 	)
 
 	for trk {
-		var in = &sdkiam.ListGroupsInput{
-			PathPrefix: sdkaws.String(prefix),
+		var in = &sdkiam.ListGroupsInput{}
+		if len(prefix) > 0 {
+			in.PathPrefix = sdkaws.String(prefix)
 		}
 
 		if mrk != nil && len(*mrk) > 0 {

--- a/aws/group/group.go
+++ b/aws/group/group.go
@@ -28,6 +28,7 @@ package group
 import (
 	sdkaws "github.com/aws/aws-sdk-go-v2/aws"
 	sdkiam "github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 )
 
 func (cli *client) List() (map[string]string, error) {
@@ -42,6 +43,93 @@ func (cli *client) List() (map[string]string, error) {
 
 		return res, nil
 	}
+}
+
+func (cli *client) Walk(prefix string, fct GroupFunc) error {
+	var (
+		err error
+		out *sdkiam.ListGroupsOutput
+		mrk *string
+		trk = true
+	)
+
+	for trk {
+		var in = &sdkiam.ListGroupsInput{
+			PathPrefix: sdkaws.String(prefix),
+		}
+
+		if mrk != nil && len(*mrk) > 0 {
+			in.Marker = mrk
+		}
+
+		out, err = cli.iam.ListGroups(cli.GetContext(), in)
+
+		if err != nil {
+			return cli.GetError(err)
+		} else if out == nil || len(out.Groups) < 1 {
+			return nil
+		} else {
+			trk = false
+			mrk = nil
+		}
+
+		for _, g := range out.Groups {
+			if !fct(g) {
+				return nil
+			}
+		}
+
+		if out.IsTruncated && out.Marker != nil && len(*out.Marker) > 0 {
+			trk = true
+			mrk = out.Marker
+		}
+	}
+	return nil
+}
+
+func (cli *client) detachPoliciesFromGroup(groupName string) error {
+	attachedPoliciesOutput, err := cli.iam.ListAttachedGroupPolicies(cli.GetContext(),
+		&sdkiam.ListAttachedGroupPoliciesInput{
+			GroupName: sdkaws.String(groupName),
+		})
+	if err != nil {
+		return cli.GetError(err)
+	}
+
+	for _, policy := range attachedPoliciesOutput.AttachedPolicies {
+		_, err := cli.iam.DetachGroupPolicy(cli.GetContext(),
+			&sdkiam.DetachGroupPolicyInput{
+				GroupName: sdkaws.String(groupName),
+				PolicyArn: policy.PolicyArn,
+			})
+		if err != nil {
+			return cli.GetError(err)
+		}
+	}
+
+	return nil
+}
+
+func (cli *client) DetachGroups(prefix string) ([]string, error) {
+	var detachedGroupNames []string
+	err := cli.Walk(prefix, func(group types.Group) bool {
+		if *group.GroupName == "FullAccessGroup" || *group.GroupName == "ReadOnlyGroup" {
+			return true
+		}
+
+		if err := cli.detachPoliciesFromGroup(*group.GroupName); err != nil {
+			return false
+		}
+
+		detachedGroupNames = append(detachedGroupNames, *group.GroupName)
+		return true
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return detachedGroupNames, nil
 }
 
 func (cli *client) Add(groupName string) error {

--- a/aws/group/interface.go
+++ b/aws/group/interface.go
@@ -41,17 +41,17 @@ type client struct {
 }
 
 type PoliciesWalkFunc func(err error, pol sdktps.AttachedPolicy) error
-
+type GroupFunc func(group sdktps.Group) bool
 type Group interface {
 	UserList(username string) ([]string, error)
+	DetachGroups(prefix string) ([]string, error)
 	UserCheck(username, groupName string) (error, bool)
 	UserAdd(username, groupName string) error
 	UserRemove(username, groupName string) error
-
+	Walk(prefix string, fct GroupFunc) error
 	List() (map[string]string, error)
 	Add(groupName string) error
 	Remove(groupName string) error
-
 	PolicyList(groupName string) (map[string]string, error)
 	PolicyAttach(groupName, polArn string) error
 	PolicyDetach(groupName, polArn string) error

--- a/aws/policy/interface.go
+++ b/aws/policy/interface.go
@@ -39,21 +39,20 @@ type client struct {
 	iam *iam.Client
 	s3  *s3.Client
 }
-
+type PolicyFunc func(policyArn string) bool
 type Policy interface {
 	List() (map[string]string, error)
-
 	Get(arn string) (*types.Policy, error)
 	Add(name, desc, policy string) (string, error)
 	Update(polArn, polContents string) error
 	Delete(polArn string) error
-
 	VersionList(arn string, maxItem int32, noDefaultVersion bool) (map[string]string, error)
 	VersionGet(arn string, vers string) (*types.PolicyVersion, error)
 	VersionAdd(arn string, doc string) error
 	VersionDel(arn string, vers string) error
-
 	CompareUpdate(arn string, doc string) (upd bool, err error)
+	Walk(prefix string, fct PolicyFunc) error
+	GetAllPolicies(prefix string) ([]string, error)
 }
 
 func New(ctx context.Context, bucket, region string, iam *iam.Client, s3 *s3.Client) Policy {

--- a/aws/role/interface.go
+++ b/aws/role/interface.go
@@ -41,18 +41,19 @@ type client struct {
 }
 
 type PoliciesWalkFunc func(err error, pol sdktps.AttachedPolicy) error
-
+type RoleFunc func(roleName string) bool
 type Role interface {
 	List() ([]sdktps.Role, error)
 	Check(name string) (string, error)
 	Add(name, role string) (string, error)
 	Delete(roleName string) error
-
 	PolicyAttach(policyARN, roleName string) error
 	PolicyDetach(policyARN, roleName string) error
 	PolicyListAttached(roleName string) ([]sdktps.AttachedPolicy, error)
 	PolicyAttachedList(roleName, marker string) ([]sdktps.AttachedPolicy, string, error)
 	PolicyAttachedWalk(roleName string, fct PoliciesWalkFunc) error
+	Walk(prefix string, fct RoleFunc) error
+	DetachRoles(prefix string) ([]string, error)
 }
 
 func New(ctx context.Context, bucket, region string, iam *sdkiam.Client, s3 *sdksss.Client) Role {

--- a/aws/user/interface.go
+++ b/aws/user/interface.go
@@ -41,27 +41,26 @@ type client struct {
 }
 
 type PoliciesWalkFunc func(err error, pol sdktps.AttachedPolicy) error
-
+type UserFunc func(username string) bool
 type User interface {
 	List() (map[string]string, error)
 	Get(username string) (*sdktps.User, error)
 	Create(username string) error
 	Delete(username string) error
-
 	PolicyPut(policyDocument, policyName, username string) error
 	PolicyAttach(policyARN, username string) error
 	PolicyDetach(policyARN, username string) error
 	PolicyAttachedList(username, marker string) ([]sdktps.AttachedPolicy, string, error)
 	PolicyAttachedWalk(username string, fct PoliciesWalkFunc) error
-
 	LoginCheck(username string) error
 	LoginCreate(username, password string) error
 	LoginDelete(username string) error
-
 	AccessListAll(username string) ([]sdktps.AccessKeyMetadata, error)
 	AccessList(username string) (map[string]bool, error)
 	AccessCreate(username string) (string, string, error)
 	AccessDelete(username, accessKey string) error
+	Walk(prefix string, fct UserFunc) error
+	DetachUsers(prefix string) ([]string, error)
 }
 
 func New(ctx context.Context, bucket, region string, iam *sdkiam.Client, s3 *sdksss.Client) User {

--- a/aws/user/interface.go
+++ b/aws/user/interface.go
@@ -41,7 +41,7 @@ type client struct {
 }
 
 type PoliciesWalkFunc func(err error, pol sdktps.AttachedPolicy) error
-type UserFunc func(username string) bool
+type UserFunc func(user sdktps.User) bool
 type User interface {
 	List() (map[string]string, error)
 	Get(username string) (*sdktps.User, error)

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/xanzy/go-gitlab v0.102.0
 	github.com/xhit/go-simple-mail v2.2.2+incompatible
 	github.com/xujiajun/utils v0.0.0-20220904132955-5f7c5b914235
-	golang.org/x/crypto v0.22.0
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8
 	golang.org/x/net v0.24.0
 	golang.org/x/oauth2 v0.19.0
@@ -210,6 +209,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.25.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.7.0 // indirect
+	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.20.0 // indirect


### PR DESCRIPTION
- For user role policy and group added a Walk func that supports pagination and takes a prefix as an input string
- For user : 
   DetachUsers(prefix string) ([]string, error) detach users from policies and groups and returns all usernames for a giving prefix it 
   embeds the Walk func for pagination support
- For policy:
   GetAllPolicies(prefix string) ([]string, error) returns all the policies ARNs for a giving input prefix it embeds the Walk func for 
   pagination support
- For role:
  DetachRoles(prefix string) ([]string, error) detach all roles from policies and returns all the rolenames for a giving input prefix it 
  embeds the Walk func for pagination support
- For group:
  DetachGroups(prefix string) ([]string, error) detach all groups from policies and returns all the groupnames for a giving input 
  prefix it embeds the Walk func for pagination support