### PR TITLE
Fix to accept first numeric character in aws model

### DIFF
--- a/aws/configCustom/models.go
+++ b/aws/configCustom/models.go
@@ -63,7 +63,7 @@ type awsModel struct {
 func (c *awsModel) Validate() error {
 	err := ErrorConfigValidator.Error(nil)
 
-	backupC := c
+	backupC := *c
 	// Only if the first character is numeric
 	if !unicode.IsLetter(rune(c.Model.Bucket[0])) {
 		backupC.Bucket = "f" + c.Bucket[1:]


### PR DESCRIPTION
_This is a temporary fix needed to avoid unexpected behavior about real world use cases vs RFC specs._

Fix Validate function in golib to have a workaround about go-playground validation : 
- `validate: "hostname"` tag with a starting numeric character for bucket names

From the RFC 952, we can read : 
_A "name" (Net, Host, Gateway, or Domain name) is a text string up
   to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus
   sign (-), and period (.).  Note that periods are only allowed when
   they serve to delimit components of "domain style names". (See
   [RFC-921](https://datatracker.ietf.org/doc/html/rfc921), "Domain Name System Implementation Schedule", for
   background).  No blank or space characters are permitted as part of a
   name. No distinction is made between upper and lower case.  **The first
   character must be an alpha character**.  The last character must not be
   a minus sign or period._
