### PR TITLE
golib retro sub pkg

### DIFF
--- a/retro/README.md
+++ b/retro/README.md
@@ -1,0 +1,22 @@
+# retro
+
+`retro` is a golib Golang sub-package designed to support backward-compatible models through semantic versioning. It introduces a new struct field tag, `retro`, which manages the serialization and deserialization of model fields based on specified versions.
+
+`retro` works with `json`, `yaml`, and `toml` formats and dynamically marshals or unmarshals model data according to the version in use.
+
+## Key Features
+
+- The `retro:"default"` tag indicates which fields should be considered when no version is specified.
+- Fields without the `retro` tag but with format tags (like `json`, `yaml`, or `toml`), and without `omitempty`, will be included in all versions.
+- `retro` supports logical operators like `>`, `<`, `>=`, and `<=` in version constraints, allowing fine-grained control over when fields should be included or excluded based on the version.
+- `retro` intelligently handles conflicting version definitions, such as `retro:">v1.0.0,>v1.0.3"`, ensuring valid behavior and in case on conflicts or any wrong retro tag definition the field will be ignored in the serialization and deserialization.
+- Versioning exceptions can be managed as well. For example, `retro:">v1.0.0,v0.0.3"` will include the field even if `v0.0.3` doesn’t meet the condition `>v1.0.0` due to the explicit exception.
+- `retro` allows easily to activate the standard serialization deserialization for your model and to work only with the standard methodologies if needed bypassing `retro` features.
+
+Additionally, `retro` respects custom marshal/unmarshal behavior defined for fields in the `json`, `yaml`, and `toml` formats, ensuring seamless integration with your model's existing logic.
+
+
+## Examples and use cases
+
+The retro_test.go file contains real world scenarios and examples on the retro features and usage.  
+

--- a/retro/encoding.go
+++ b/retro/encoding.go
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Nicolas JUHEL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package retro
+
+import (
+	"github.com/pelletier/go-toml"
+	"gopkg.in/yaml.v3"
+)
+
+func (m Model[T]) MarshalJSON() ([]byte, error) {
+	return m.marshal(FormatJSON)
+}
+
+func (m *Model[T]) UnmarshalJSON(data []byte) error {
+	return m.unmarshal(data, FormatJSON)
+}
+
+func (m Model[T]) MarshalYAML() (interface{}, error) {
+
+	data, err := m.marshal(FormatYAML)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return string(data), nil
+
+}
+
+func (m *Model[T]) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var (
+		tmp     interface{}
+		err     error
+		rawData []byte
+	)
+
+	if err = unmarshal(&tmp); err != nil {
+		return err
+	}
+
+	if rawData, err = yaml.Marshal(tmp); err != nil {
+		return err
+	}
+
+	return m.unmarshal(rawData, FormatYAML)
+}
+
+func (m Model[T]) MarshalTOML() ([]byte, error) {
+	return m.marshal(FormatTOML)
+}
+
+func (m *Model[T]) UnmarshalTOML(data interface{}) (err error) {
+
+	var rawData []byte
+
+	if rawData, err = toml.Marshal(data.(map[string]interface{})); err != nil {
+		return err
+	}
+
+	return m.unmarshal(rawData, FormatTOML)
+}

--- a/retro/format.go
+++ b/retro/format.go
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Nicolas JUHEL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package retro
+
+type Format string
+
+const (
+	FormatJSON Format = "json"
+	FormatYAML Format = "yaml"
+	FormatTOML Format = "toml"
+)
+
+var SupportedFormats = []Format{FormatJSON, FormatYAML, FormatTOML}
+
+func (f Format) Valid() bool {
+	for _, validFormat := range SupportedFormats {
+		if f == validFormat {
+			return true
+		}
+	}
+	return false
+}

--- a/retro/model.go
+++ b/retro/model.go
@@ -1,0 +1,285 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Nicolas JUHEL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package retro
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+
+	"github.com/pelletier/go-toml"
+	"gopkg.in/yaml.v3"
+)
+
+// Model => The generic struct that handles retro functionality
+type Model[T any] struct {
+	Struct   T
+	Standard bool
+}
+
+func (m Model[T]) marshal(format Format) ([]byte, error) {
+
+	if !format.Valid() {
+		return nil, errors.New("unsupported format")
+	}
+
+	if m.Standard == true {
+		switch format {
+		case FormatJSON:
+			return json.Marshal(m.Struct)
+		case FormatYAML:
+			return yaml.Marshal(m.Struct)
+		case FormatTOML:
+			return toml.Marshal(m.Struct)
+		default:
+			return nil, errors.New("unsupported format")
+		}
+	}
+
+	var (
+		modelMap = make(map[string]interface{})
+		key      string
+	)
+
+	val := reflect.Indirect(reflect.ValueOf(&m.Struct))
+
+	version := val.FieldByName("Version").String()
+
+	if version == "" {
+		version = "default"
+	}
+
+	for i := 0; i < val.NumField(); i++ {
+
+		typeField := val.Type().Field(i)
+
+		formatTag := typeField.Tag.Get(string(format))
+
+		retroTag := typeField.Tag.Get("retro")
+
+		supported := isVersionSupported(version, retroTag)
+
+		if !supported {
+			continue
+		}
+
+		if formatTag != "" {
+			tagParts := strings.Split(formatTag, ",")
+			key = tagParts[0]
+		} else {
+			key = val.Type().Field(i).Name
+		}
+
+		fieldValue := val.Field(i)
+
+		// Check for "omitempty"
+		if len(strings.Split(formatTag, ",")) > 1 &&
+			strings.Split(formatTag, ",")[1] == "omitempty" {
+
+			if isEmptyValue(fieldValue) {
+				continue
+			}
+		}
+		// Marshal the field value and add to the map
+		modelMap[key] = fieldValue.Interface()
+	}
+
+	switch format {
+	case FormatJSON:
+		return json.Marshal(modelMap)
+	case FormatYAML:
+		return yaml.Marshal(modelMap)
+	case FormatTOML:
+		return toml.Marshal(modelMap)
+	default:
+		return nil, errors.New("unsupported format")
+	}
+}
+
+func (m *Model[T]) unmarshal(data []byte, format Format) error {
+
+	if !format.Valid() {
+		return errors.New("unsupported format")
+	}
+
+	if m.Standard == true {
+		switch format {
+		case FormatJSON:
+			return json.Unmarshal(data, &m.Struct)
+		case FormatYAML:
+			return yaml.Unmarshal(data, &m.Struct)
+		case FormatTOML:
+			return toml.Unmarshal(data, &m.Struct)
+		default:
+			return errors.New("unsupported format")
+		}
+	}
+
+	var (
+		tempMap    map[string]interface{}
+		version    string
+		exists     bool
+		rawField   interface{}
+		rawMessage []byte
+		err        error
+	)
+
+	// Unmarshal based on the provided format
+	switch format {
+	case FormatJSON:
+		if err = json.Unmarshal(data, &tempMap); err != nil {
+			return err
+		}
+	case FormatYAML:
+		if err = yaml.Unmarshal(data, &tempMap); err != nil {
+			return err
+		}
+	case FormatTOML:
+		if err = toml.Unmarshal(data, &tempMap); err != nil {
+			return err
+		}
+	default:
+		return errors.New("unsupported format")
+	}
+
+	version, _ = tempMap["version"].(string)
+
+	if version == "" {
+		version = "default"
+	}
+
+	val := reflect.Indirect(reflect.ValueOf(&m.Struct))
+
+	for i := 0; i < val.NumField(); i++ {
+
+		typeField := val.Type().Field(i)
+
+		formatTag := typeField.Tag.Get(string(format))
+
+		fieldName := strings.Split(formatTag, ",")[0]
+
+		retroTag := typeField.Tag.Get("retro")
+
+		if !isVersionSupported(version, retroTag) {
+			continue
+		}
+
+		if rawField, exists = tempMap[fieldName]; exists {
+
+			field := val.Field(i)
+
+			if field.CanAddr() {
+				field = field.Addr()
+			}
+
+			if format == FormatJSON {
+
+				if unmarshaler, ok := field.Interface().(json.Unmarshaler); ok {
+
+					if rawMessage, err = json.Marshal(rawField); err != nil {
+						return err
+					}
+
+					if err = unmarshaler.UnmarshalJSON(rawMessage); err != nil {
+						return err
+					}
+
+				} else {
+
+					if rawMessage, err = json.Marshal(rawField); err != nil {
+						return err
+					}
+
+					if err = json.Unmarshal(rawMessage, field.Interface()); err != nil {
+						return err
+					}
+				}
+
+			} else if format == FormatYAML {
+
+				if unmarshaler, ok := field.Interface().(yaml.Unmarshaler); ok {
+
+					var node1 yaml.Node
+
+					if rawMessage, err = yaml.Marshal(rawField); err != nil {
+						return err
+					}
+
+					if err = yaml.Unmarshal(rawMessage, &node1); err != nil {
+						return err
+					}
+
+					if err = unmarshaler.UnmarshalYAML(&node1); err != nil {
+						return err
+					}
+
+				} else {
+
+					if rawMessage, err = yaml.Marshal(rawField); err != nil {
+						return err
+					}
+
+					if err = yaml.Unmarshal(rawMessage, field.Interface()); err != nil {
+						return err
+					}
+				}
+
+			} else if format == FormatTOML {
+
+				if unmarshaler, ok := field.Interface().(toml.Unmarshaler); ok {
+
+					if rawMessage, err = toml.Marshal(map[string]interface{}{
+						fieldName: rawField,
+					}); err != nil {
+						return err
+					}
+
+					if err = unmarshaler.UnmarshalTOML(rawMessage); err != nil {
+						return err
+					}
+
+				} else {
+
+					if rawMessage, err = toml.Marshal(map[string]interface{}{
+						fieldName: rawField,
+					}); err != nil {
+						return err
+					}
+
+					if err = toml.Unmarshal(rawMessage, &m.Struct); err != nil {
+						return err
+					}
+				}
+			}
+
+		}
+
+	}
+
+	return nil
+}

--- a/retro/retro_test.go
+++ b/retro/retro_test.go
@@ -1,0 +1,578 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Nicolas JUHEL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package retro_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/nabbar/golib/retro"
+	"github.com/pelletier/go-toml"
+	yaml "gopkg.in/yaml.v3"
+)
+
+type Test struct {
+	LastName     string     `json:"lastName" yaml:"lastName" toml:"lastName" retro:"v1.0.0,>v1.0.3"` // greater than v1.0.3 except v1.0.0
+	Age          int        `json:"age,omitempty" yaml:"age,omitempty" toml:"age,omitempty"`         // this if not 0 should be included in all the models because no retro tag
+	Name         string     `json:"name"  yaml:"name" toml:"name" retro:">v1.0.0"`                   // only if version strict greater than v1.0.0
+	Version      string     `json:"version,omitempty" yaml:"version,omitempty" toml:"version,omitempty"`
+	Salary       float64    `json:"salary,omitempty" yaml:"salary,omitempty" toml:"salary,omitempty" retro:"<v1.0.2"`                                     // only if version strict lesser than v1.0.2
+	Active       bool       `json:"active,omitempty" yaml:"active,omitempty" toml:"active,omitempty" retro:">=v1.0.2"`                                    // only if version greater or equal to v1.0.2
+	Address      Address    `json:"address" yaml:"address" toml:"address" retro:"<=v1.0.0"`                                                               // only if version lesser or equal to v1.0.0
+	Job          string     `json:"job" yaml:"job" toml:"job" retro:">v1.0.1,<v1.0.4"`                                                                    // only v1.0.2 and v1.0.3
+	Status       Status     `json:"status" yaml:"status" toml:"status" retro:"default,>v1.0.1,<v1.0.4"`                                                   // default (meaning no versioning) or only v1.0.2 and v1.0.3
+	Married      bool       `json:"married" yaml:"married" toml:"married" retro:">=v1.0.0,<v1.0.2"`                                                       // v1.0.0 v1.0.1
+	BirthDate    *time.Time `json:"birthdate,omitempty" yaml:"birthdate,omitempty" toml:"birthdate,omitempty" retro:"default,>=v1.0.0,<v1.0.2"`           // v1.0.0 v1.0.1 and default
+	Degree       string     `json:"degree" yaml:"degree" toml:"degree" retro:">v1.0.0,<=v1.0.2"`                                                          // v1.0.1 v1.0.2
+	Phone        int32      `json:"phone,omitempty" yaml:"phone,omitempty" toml:"phone,omitempty" retro:"default,>v1.0.0,<=v1.0.2"`                       // v1.0.1 v1.0.2 and default
+	Other        []string   `json:"other" yaml:"other" toml:"other" retro:">=v1.0.0,<=v1.0.2"`                                                            // v1.0.0 v1.0.1 v1.0.2
+	LuckyNumbers []int      `json:"luckyNumbers,omitempty" yaml:"luckyNumbers,omitempty" toml:"luckyNumbers,omitempty" retro:"default,>=v1.0.0,<=v1.0.2"` // v1.0.0 v1.0.1 v1.0.2 and default
+	Weight       int        `json:"weight,omitempty" yaml:"weight,omitempty" toml:"weight,omitempty" retro:"default,v1.0.0"`                              // v1.0.0 and default
+	Height       int        `json:"height" yaml:"height" toml:"height" retro:"v1.0.0"`                                                                    // v1.0.0 only
+	Id           string     `json:"id" yaml:"id"  toml:"id" retro:"v1.0.0,v1.0.3"`                                                                        // v1.0.0 and v1.0.3 only
+	Languages    []string   `json:"languages,omitempty" yaml:"languages,omitempty" toml:"languages,omitempty" retro:"default,v1.0.0,v1.0.3"`              // v1.0.0 and v1.0.3 and default
+	Email        string     `json:"email" yaml:"email" toml:"email" retro:"<v1.0.0,v1.0.3"`                                                               // lesser than v1.0.0 expect v1.0.3
+	Available    bool       `json:"available" yaml:"available" toml:"available" retro:">v1.0.0,<=v1.0.3"`                                                 // v1.0.1 v1.0.2 v1.0.3
+	Sex          string     `json:"sex,omitempty" yaml:"sex,omitempty" toml:"sex,omitempty" retro:">v1.0.0,<=v1.0.3, v0.0.3, default"`                    // between v1.0.0 and v1.0.3 (expect v0.0.3) and default
+	Conflict     string     `json:"conflict" yaml:"conflict" toml:"conflict" retro:">v1.0.0,>v1.0.3"`                                                     // this field has non-valid retro definition and should be always ignored
+}
+
+type Standard struct {
+	A int      `json:"a" yaml:"a" toml:"a"`
+	b int      
+	C string   `json:"C" yaml:"C" toml:"C"`
+	D []string `json:"d" yaml:"d" toml:"d"`
+}
+
+type Address struct {
+	Street  string `json:"street" `
+	City    string `json:"city,omitempty"`
+}
+
+type Status int
+
+const (
+	Inactive Status = iota
+	Active
+	Pending
+)
+
+func (s Status) MarshalJSON() ([]byte, error) {
+	switch s {
+	case Inactive:
+		return json.Marshal("inactive")
+	case Active:
+		return json.Marshal("active")
+	case Pending:
+		return json.Marshal("pending")
+	default:
+		return json.Marshal("unknown")
+	}
+}
+
+func (s *Status) UnmarshalJSON(data []byte) error {
+	var statusStr string
+
+	if err := json.Unmarshal(data, &statusStr); err != nil {
+		return err
+	}
+
+	switch statusStr {
+	case "inactive":
+		*s = Inactive
+	case "active":
+		*s = Active
+	case "pending":
+		*s = Pending
+	default:
+		*s = Inactive
+	}
+	return nil
+}
+
+func TestModel_MarshalJSON(t *testing.T) {
+	var birth = time.Date(2024, 10, 8, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		model       retro.Model[Test]
+		expected    string
+		expectedErr bool
+	}{
+		{ // Test Default No Versioning + age field with no retro tag
+			model: retro.Model[Test]{Struct: Test{
+				Age:    25,
+				Name:   "Alice",
+				Active: true,
+				Address: Address{Street: "123 Main St",
+					City: "Wonderland"},
+				Status: Active},
+			},
+
+			expected: `{"age":25,"status":"active"}`,
+		},
+		{ // v1.0.3
+			model: retro.Model[Test]{Struct: Test{
+				Age:       25,
+				Name:      "Alice",
+				Active:    true,
+				Job:       "test",
+				Id:        "uc123",
+				Email:     "test@example.com",
+				Available: true,
+				Sex:       "M",
+				Version:   "v1.0.3",
+				Address:   Address{Street: "123 Main St", City: "Wonderland"},
+				Status:    Active}},
+
+			expected: `{"version":"v1.0.3","age":25,"status":"active","name":"Alice", 
+						"active":true,"job":"test","id":"uc123",
+						"email":"test@example.com","available":true,"sex":"M"}`,
+		},
+		{ // v0.0.3
+
+			model: retro.Model[Test]{Struct: Test{
+				Age:     15,
+				Version: "v0.0.3",
+				Salary:  100,
+				Address: Address{Street: "123 Main St", City: "Wonderland"},
+				Email:   "test",
+				Sex:     "F"}},
+
+			expected: `{"version":"v0.0.3","age":15,"email":"test","sex":"F",
+						"salary":100,"address":{"street":"123 Main St","city":"Wonderland"}}`,
+		},
+		{
+			model: retro.Model[Test]{Struct: Test{
+				LastName: "test",
+				Age:      34,
+				Name:     "test",
+				Version:  "v1.0.0",
+				Salary:   1500,
+				Active:   true,
+				Address: Address{
+					Street: "Joseph Bermond",
+					City:   "Valbonne",
+				},
+				Job:          "test",
+				Status:       Active,
+				Married:      true,
+				BirthDate:    &birth,
+				Degree:       "test",
+				Phone:        12345850,
+				Other:        []string{"tt", "aa", "bb"},
+				LuckyNumbers: []int{12, 21},
+				Weight:       100,
+				Height:       190,
+				Id:           "uc123",
+				Languages:    []string{"french"},
+				Email:        "test@test.com",
+				Available:    true,
+				Sex:          "M",
+				Conflict:     "test",
+			}},
+			expected: `{"lastName": "test","salary":1500,"age": 34,"version": "v1.0.0",
+						"address": {"street": "Joseph Bermond","city": "Valbonne"},"married": true,
+						"birthdate": "2024-10-08T00:00:00Z","other": ["tt", "aa", "bb"],"luckyNumbers": 
+						[12, 21],"weight": 100,"height": 190,"id": "uc123","languages": ["french"]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		var expectedJSON, resultJSON interface{}
+
+		t.Run(tt.expected, func(t *testing.T) {
+
+			result, err := json.Marshal(tt.model)
+
+			if (err != nil) != tt.expectedErr {
+				t.Errorf("expected error: %v, got: %v", tt.expectedErr, err)
+			}
+
+			if err = json.Unmarshal([]byte(tt.expected), &expectedJSON); err != nil {
+				t.Fatalf("failed to unmarshal expected JSON: %v", err)
+			}
+
+			if err = json.Unmarshal(result, &resultJSON); err != nil {
+				t.Fatalf("failed to unmarshal result JSON: %v", err)
+			}
+
+			if !reflect.DeepEqual(expectedJSON, resultJSON) {
+				t.Errorf("expected: %+v, got: %+v", expectedJSON, resultJSON)
+			}
+		})
+	}
+}
+
+func TestModel_UnmarshalJSON(t *testing.T) {
+	var birth = time.Date(2024, 10, 8, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		input       string
+		expected    retro.Model[Test]
+		expectedErr bool
+	}{
+		{
+			input:    `{"age":25,"status":"active","weight":70}`,
+			expected: retro.Model[Test]{Struct: Test{Age: 25, Status: Active, Weight: 70}},
+		},
+		{
+			input: `{"version":"v1.0.3","age":25,"status":"active","name":"Alice", 
+					"active":true,"job":"test","id":"uc123","email":"test@example.com","available":true,"sex":"M"}`,
+			expected: retro.Model[Test]{Struct: Test{Age: 25, Name: "Alice", Active: true,
+				Job: "test", Id: "uc123", Email: "test@example.com",
+				Available: true, Sex: "M", Version: "v1.0.3", Status: Active}},
+		},
+		{
+			input: `{"lastName":"test","age":34,"name":"test","version":"v1.0.0",
+					 "salary":1500,"active":true,"address":{"street":"Joseph Bermond","city":"Valbonne"},"job":"test",
+					"status":"active","married":true,"birthdate":"2024-10-08T00:00:00Z","degree":"test","phone":12345850,
+					"other":["tt","aa","bb"],"luckyNumbers":[12,21],"weight":100,"height":190,
+					"id":"uc123","languages":["french"],
+					"email":"test@test.com","available":true,"sex":"M","conflict":"test"}`,
+			expected: retro.Model[Test]{
+				Struct: Test{
+					LastName: "test",
+					Age:      34,
+					Version:  "v1.0.0",
+					Salary:   1500,
+					Address: Address{
+						Street: "Joseph Bermond",
+						City:   "Valbonne",
+					},
+					Married:      true,
+					BirthDate:    &birth,
+					Other:        []string{"tt", "aa", "bb"},
+					LuckyNumbers: []int{12, 21},
+					Weight:       100,
+					Height:       190,
+					Id:           "uc123",
+					Languages:    []string{"french"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		var result retro.Model[Test]
+
+		t.Run(tt.input, func(t *testing.T) {
+
+			err := json.Unmarshal([]byte(tt.input), &result)
+
+			if (err != nil) != tt.expectedErr {
+				t.Errorf("expected error: %v, got: %v", tt.expectedErr, err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected: %+v, got: %+v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestModel_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		model       retro.Model[Test]
+		expected    string
+		expectedErr bool
+	}{
+		{ // Example Test Case
+			model: retro.Model[Test]{Struct: Test{Age: 25, Status: Active}},
+			expected: `age: 25
+status: 1
+`,
+			expectedErr: false,
+		},
+		{ // v0.0.3
+			model: retro.Model[Test]{Struct: Test{
+				Age:     15,
+				Version: "v0.0.3",
+				Salary:  100,
+				Address: Address{Street: "123 Main St", City: "Wonderland"},
+				Email:   "test",
+				Sex:     "F",
+			}},
+			expected: `version: v0.0.3
+age: 15
+email: test
+sex: F
+salary: 100
+address:
+  street: 123 Main St
+  city: Wonderland
+`,
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.expected, func(t *testing.T) {
+			var (
+				m   retro.Model[Test]
+				err error
+			)
+
+			if _, err = yaml.Marshal(&tt.model); (err != nil) != tt.expectedErr {
+				t.Errorf("expected error: %v, got: %v", tt.expectedErr, err)
+			}
+
+			if err = yaml.Unmarshal([]byte(tt.expected), &m); err != nil {
+				t.Fatalf("failed to unmarshal expected YAML: %v", err)
+			}
+
+			if !reflect.DeepEqual(m, tt.model) {
+
+				t.Errorf("expected: %+v, got: %+v", tt.model, m)
+			}
+
+		})
+	}
+}
+
+func TestModel_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    retro.Model[Test]
+		expectedErr bool
+	}{
+		{
+			input: `age: 25
+status: 1
+weight: 70`,
+			expected: retro.Model[Test]{Struct: Test{Age: 25, Status: Active, Weight: 70}},
+		},
+		{
+			input: `version: v1.0.3
+age: 25
+status: 1
+name: Alice
+active: true
+job: test
+id: uc123
+email: test@example.com
+available: true
+sex: M`,
+			expected: retro.Model[Test]{Struct: Test{Age: 25, Name: "Alice", Active: true, Job: "test", Id: "uc123",
+				Email:     "test@example.com",
+				Available: true, Sex: "M", Version: "v1.0.3", Status: Active}},
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.input, func(t *testing.T) {
+
+			var result retro.Model[Test]
+
+			err := yaml.Unmarshal([]byte(tt.input), &result)
+
+			if (err != nil) != tt.expectedErr {
+				t.Errorf("expected error: %v, got: %v", tt.expectedErr, err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+
+				t.Errorf("expected: %+v, got: %+v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestModel_MarshalTOML(t *testing.T) {
+	var birth = time.Date(2024, 10, 8, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		model       retro.Model[Test]
+		expected    string
+		expectedErr bool
+	}{
+		{
+			model: retro.Model[Test]{Struct: Test{
+				LastName: "test",
+				Age:      34,
+				Name:     "test",
+				Salary:   1500,
+				Active:   true,
+				Address: Address{
+					Street: "Joseph Bermond",
+					City:   "Valbonne",
+				},
+				Job:          "test",
+				Status:       Active,
+				Married:      true,
+				BirthDate:    &birth,
+				Degree:       "test",
+				Phone:        12345850,
+				Other:        []string{"tt", "aa", "bb"},
+				LuckyNumbers: []int{12, 21},
+				Weight:       100,
+				Height:       10,
+				Id:           "uc123",
+				Languages:    []string{"french"},
+				Email:        "test@test.com",
+				Available:    true,
+				Sex:          "M",
+				Conflict:     "test",
+			}},
+			expected: "age = 34\nbirthdate = \"2024-10-08T00:00:00Z\"\nlanguages = [\"french\"]\nluckyNumbers = [12, 21]" +
+				"\nphone = 12345850\nsex = \"M\"\nstatus = 1\nweight = 100\n", // TOML representation
+		},
+	}
+	for _, tt := range tests {
+		var expectedTOML, resultTOML interface{}
+
+		t.Run(tt.expected, func(t *testing.T) {
+
+			result, err := toml.Marshal(tt.model)
+
+			if (err != nil) != tt.expectedErr {
+				t.Errorf("expected error: %v, got: %v", tt.expectedErr, err)
+			}
+
+			if err = toml.Unmarshal([]byte(tt.expected), &expectedTOML); err != nil {
+				t.Fatalf("failed to unmarshal expected TOML: %v", err)
+			}
+
+			if err = toml.Unmarshal(result, &resultTOML); err != nil {
+				t.Fatalf("failed to unmarshal result TOML: %v", err)
+			}
+
+			if !reflect.DeepEqual(expectedTOML, resultTOML) {
+				t.Errorf("expected: %+v, got: %+v", expectedTOML, resultTOML)
+			}
+		})
+	}
+}
+
+func TestModel_UnmarshalTOML(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    retro.Model[Test]
+		expectedErr bool
+	}{
+		{
+			input:    "age = 25\nstatus = 1\nemail = \"test@testcom\"\n",
+			expected: retro.Model[Test]{Struct: Test{Age: 25, Status: Active}},
+		},
+	}
+
+	for _, tt := range tests {
+		var result retro.Model[Test]
+
+		t.Run(tt.input, func(t *testing.T) {
+			err := toml.Unmarshal([]byte(tt.input), &result)
+
+			if (err != nil) != tt.expectedErr {
+				t.Errorf("expected error: %v, got: %v", tt.expectedErr, err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected: %+v, got: %+v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// Standard to true means that the retro Model will Marshalled Unmarshalled directly with the standard encoders
+func TestModel_MarshalStandard(t *testing.T) {
+	var (
+		err error
+		// Expected struct after unmarshaling
+		expected = retro.Model[Standard]{
+			Struct: Standard{
+				A: 12,
+				C: "test",
+				D: []string{"a", "b"},
+			},
+			Standard: true,
+		}
+		// Struct to be used for unmarshaling and comparison
+		m = retro.Model[Standard]{
+			Standard: true,
+		}
+	)
+
+	tests := []struct {
+		input                                    retro.Model[Standard]
+		expectedJSON, expectedYAML, expectedTOML string
+		expectedErr                              bool
+	}{
+		{
+			input: retro.Model[Standard]{
+				Struct: Standard{
+					A: 12,
+					b: 25,
+					C: "test",
+					D: []string{"a", "b"},
+				},
+				Standard: true,
+			},
+
+			expectedJSON: `{"a":12,"C":"test","d":["a","b"]}`,
+			expectedYAML: `
+a: 12
+C: test
+b: 25
+d:
+  - a
+  - b
+`,
+			expectedTOML: `a = 12
+C = "test"
+d = ["a", "b"]
+`,
+		},
+	}
+
+	for _, tt := range tests {
+
+		if err = yaml.Unmarshal([]byte(tt.expectedYAML), &m); (err != nil) != tt.expectedErr {
+			t.Fatalf("failed to unmarshal expected YAML: %v", err)
+		}
+
+		if !reflect.DeepEqual(m.Struct, expected.Struct) {
+			t.Errorf("YAML: expected: %+v, got: %+v", expected, m)
+		}
+
+		if err = json.Unmarshal([]byte(tt.expectedJSON), &m); (err != nil) != tt.expectedErr {
+			t.Fatalf("failed to unmarshal expected JSON: %v", err)
+		}
+
+		if !reflect.DeepEqual(m.Struct, expected.Struct) {
+			t.Errorf("JSON: expected: %+v, got: %+v", expected, m)
+		}
+
+		if err = toml.Unmarshal([]byte(tt.expectedTOML), &m); (err != nil) != tt.expectedErr {
+			t.Fatalf("failed to unmarshal expected TOML: %v", err)
+		}
+
+		if !reflect.DeepEqual(m.Struct, expected.Struct) {
+			t.Errorf("TOML: expected: %+v, got: %+v", expected, m)
+		}
+	}
+}

--- a/retro/utils.go
+++ b/retro/utils.go
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Nicolas JUHEL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package retro
+
+import (
+	"reflect"
+)
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.String, reflect.Array, reflect.Slice, reflect.Map:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return v.Int() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	default:
+	}
+	return false
+}

--- a/retro/version.go
+++ b/retro/version.go
@@ -1,0 +1,229 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Nicolas JUHEL
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+package retro
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var versionRegex = regexp.MustCompile(`^(<=|>=|<|>)?v(\d+)\.(\d+)\.(\d+)$`)
+
+func isVersionSupported(version, retro string) bool {
+
+	var (
+		dualBoundaries, standaloneSatisfied       bool
+		lowerVersion, upperVersion, lowOp, highOp string
+	)
+
+	// No retro tag means the field is always supported.
+	if retro == "" {
+		return true
+	}
+
+	versions := strings.Split(retro, ",")
+
+	if !validRetroTag(versions) {
+		return false
+	}
+
+	if detectedBoundaries(versions) {
+		dualBoundaries = true
+	}
+
+	for _, ver := range versions {
+		ver = strings.TrimSpace(ver)
+
+		// If the current version is "default", check if retro tag has it.
+		if version == "default" {
+			if ver == "default" {
+				return true
+			}
+			continue
+		}
+
+		// Check for standalone version (exception)
+		if !strings.Contains(ver, ">") && !strings.Contains(ver, "<") &&
+			!strings.Contains(ver, "<=") && !strings.Contains(ver, ">=") {
+			if checkCondition(version, ver, "==") {
+				standaloneSatisfied = true
+			}
+
+		}
+
+		// Parse the version operator
+		operator, compareVersion := parseOperator(ver)
+
+		switch operator {
+		case ">=", ">":
+			lowerVersion = compareVersion
+			lowOp = operator
+		case "<=", "<":
+			upperVersion = compareVersion
+			highOp = operator
+		}
+
+	}
+
+	if standaloneSatisfied {
+		return true
+	}
+
+	if dualBoundaries {
+		return checkCondition(version, lowerVersion, lowOp) && checkCondition(version, upperVersion, highOp)
+	}
+
+	if upperVersion != "" {
+		return checkCondition(version, upperVersion, highOp)
+	}
+
+	if lowerVersion != "" {
+		return checkCondition(version, lowerVersion, lowOp)
+	}
+
+	return false
+
+}
+
+// Parse the operator and return it with the version string
+func parseOperator(ver string) (operator, compareVersion string) {
+	switch {
+	case strings.HasPrefix(ver, ">="):
+		operator = ">="
+		compareVersion = strings.TrimPrefix(ver, ">=")
+	case strings.HasPrefix(ver, "<="):
+		operator = "<="
+		compareVersion = strings.TrimPrefix(ver, "<=")
+	case strings.HasPrefix(ver, ">"):
+		operator = ">"
+		compareVersion = strings.TrimPrefix(ver, ">")
+	case strings.HasPrefix(ver, "<"):
+		operator = "<"
+		compareVersion = strings.TrimPrefix(ver, "<")
+	default:
+		compareVersion = ver
+	}
+	return
+}
+
+// Check if the version is valid
+func isValidVersion(version string) bool {
+	return versionRegex.MatchString(version) || version == "default"
+}
+
+// Check the version condition using the operator
+func checkCondition(version, compareVersion, operator string) bool {
+	comparison := compareVersions(strings.TrimPrefix(version, "v"),
+		strings.TrimPrefix(compareVersion, "v"))
+
+	switch operator {
+	case ">":
+		return comparison > 0
+	case "<":
+		return comparison < 0
+	case ">=":
+		return comparison >= 0
+	case "<=":
+		return comparison <= 0
+	case "==":
+		return comparison == 0
+	default:
+		return false
+	}
+}
+
+// Compares two version strings by breaking them into major, minor, and patch parts
+func compareVersions(v1, v2 string) int {
+	v1Parts := strings.Split(v1, ".")
+	v2Parts := strings.Split(v2, ".")
+	for i := 0; i < 3; i++ {
+		num1, num2 := 0, 0
+		if i < len(v1Parts) {
+			num1, _ = strconv.Atoi(v1Parts[i])
+		}
+		if i < len(v2Parts) {
+			num2, _ = strconv.Atoi(v2Parts[i])
+		}
+		if num1 < num2 {
+			return -1
+		} else if num1 > num2 {
+			return 1
+		}
+	}
+	return 0
+}
+
+// Ensure the retro tag has valid boundaries and that operators aren't duplicated
+func validRetroTag(values []string) bool {
+	operatorCount := make(map[string]bool)
+
+	for _, version := range values {
+		version = strings.TrimSpace(version)
+
+		if !isValidVersion(version) {
+			return false
+		}
+
+		if strings.HasPrefix(version, ">") {
+			if operatorCount[">"] {
+				return false
+			}
+			operatorCount[">"] = true
+		} else if strings.HasPrefix(version, "<") {
+			if operatorCount["<"] {
+				return false
+			}
+			operatorCount["<"] = true
+		}
+	}
+
+	return true
+}
+
+// Check if the tag contain a dual boundary
+func detectedBoundaries(versions []string) bool {
+	var (
+		hasGreater, hasLess bool
+	)
+
+	for _, version := range versions {
+		version = strings.TrimSpace(version)
+
+		if strings.HasPrefix(version, ">") {
+			hasGreater = true
+		} else if strings.HasPrefix(version, "<") {
+			hasLess = true
+		}
+
+		if hasGreater && hasLess {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
# retro

`retro` is a golib Golang sub-package designed to support backward-compatible models through semantic versioning. It introduces a new struct field tag, `retro`, which manages the serialization and deserialization of model fields based on specified versions.

`retro` works with `json`, `yaml`, and `toml` formats and dynamically marshals or unmarshals model data according to the version in use.
