### PR TITLE
Fix  ldap.go searchRequest

### DIFF
--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -460,7 +460,7 @@ func (lc *HelperLDAP) runSearch(filter string, attributes []string) (*ldap.Searc
 		lc.config.Basedn,
 		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
-		100, 0, false,
+		0, 0, false,
 		filter,
 		attributes,
 		nil,


### PR DESCRIPTION


## Type of Change
Please select the type of change your PR introduces by checking the appropriate box:
- [X] Fixes an issue
- [ ] Adds a new feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe it in the Description Section)

## Description
Fixing the LDAP Search Request to only 100 entry will result in an error if the retrieved data exceed this number, putting the ldap search request to 0, will work with no restricted limitations (reference LDAP rfc => https://datatracker.ietf.org/doc/html/rfc4511)