### PR TITLE
Package Ldap - Add features to filter multiple group entries

### DIFF
--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -460,7 +460,7 @@ func (lc *HelperLDAP) runSearch(filter string, attributes []string) (*ldap.Searc
 		lc.config.Basedn,
 		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
-		100, 0, false,
+		0, 0, false,
 		filter,
 		attributes,
 		nil,
@@ -546,6 +546,39 @@ func (lc *HelperLDAP) UserInfoByField(username string, fieldOfUnicValue string) 
 // GroupInfo used to retrieve the information of a given group cn.
 func (lc *HelperLDAP) GroupInfo(groupname string) (map[string]interface{}, liberr.Error) {
 	return lc.GroupInfoByField(groupname, groupFieldCN)
+}
+func (lc *HelperLDAP) AttributeFilter(search string,
+	filter string, attribute string) (map[string][]string,
+	liberr.Error) {
+
+	var (
+		err     liberr.Error
+		src     *ldap.SearchResult
+		grpInfo map[string][]string
+	)
+
+	src, err = lc.runSearch(fmt.Sprintf("(&(objectClass~=groupOfNames)(%s=%s))", filter, search), []string{})
+
+	if err != nil {
+		return grpInfo, err
+	}
+
+	if len(src.Entries) == 0 {
+		return nil, ErrorLDAPGroupNotFound.Error(nil)
+	}
+
+	grpInfo = make(map[string][]string, len(src.Entries))
+
+	for _, entry := range src.Entries {
+		for _, entryAttribute := range entry.Attributes {
+			if entryAttribute.Name == attribute {
+				grpInfo[entryAttribute.Name] = append(grpInfo[entryAttribute.Name], entryAttribute.Values...)
+			}
+		}
+	}
+
+	lc.getLogEntry(loglvl.DebugLevel, "ldap group find success").FieldAdd("ldap.group", search).FieldAdd("ldap.map", grpInfo).Log()
+	return grpInfo, nil
 }
 
 // GroupInfoByField used to retrieve the information of a given group cn, but use a given field to make the search.


### PR DESCRIPTION
adding  GroupsAttributeInfoByField (https://github.com/nabbar/golib/pull/192)
## Type of Change
Please select the type of change your PR introduces by checking the
appropriate box:
- [ ] Fixes an issue
- [X] Adds a new feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe it in the Description Section)

## Description
This function added will allow to filter multiple Ldap entries
attributes based on the user desired attribute like "cn", filter and
search string.

No need for map[string] interface as the go-ldap pkg Entry struct Values
type is a string slice.

=>https://pkg.go.dev/github.com/go-ldap/ldap/v3#EntryAttribute