### PR TITLE
Migrating mapstructure repo from mitchellh to go-viper

### DIFF
--- a/certificates/auth/models.go
+++ b/certificates/auth/models.go
@@ -29,7 +29,7 @@ package auth
 import (
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 func ViperDecoderHook() libmap.DecodeHookFuncType {

--- a/certificates/ca/models.go
+++ b/certificates/ca/models.go
@@ -30,7 +30,7 @@ import (
 	"crypto/x509"
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 type mod struct {

--- a/certificates/certs/models.go
+++ b/certificates/certs/models.go
@@ -30,7 +30,7 @@ import (
 	"crypto/tls"
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 type Certif struct {

--- a/certificates/cipher/models.go
+++ b/certificates/cipher/models.go
@@ -29,7 +29,7 @@ package curves
 import (
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 func (v Cipher) Check() bool {

--- a/certificates/curves/models.go
+++ b/certificates/curves/models.go
@@ -29,7 +29,7 @@ package curves
 import (
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 func (v Curves) Check() bool {

--- a/certificates/tlsversion/models.go
+++ b/certificates/tlsversion/models.go
@@ -29,7 +29,7 @@ package tlsversion
 import (
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 func (v Version) Check() bool {

--- a/duration/model.go
+++ b/duration/model.go
@@ -28,7 +28,7 @@ package duration
 import (
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 func ViperDecoderHook() libmap.DecodeHookFuncType {

--- a/file/perm/model.go
+++ b/file/perm/model.go
@@ -30,7 +30,7 @@ package perm
 import (
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 func ViperDecoderHook() libmap.DecodeHookFuncType {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/nabbar/golib
 
-go 1.23
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require (
 	github.com/aws/aws-sdk-go v1.55.6
@@ -21,6 +21,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-ldap/ldap/v3 v3.4.10
 	github.com/go-playground/validator/v10 v10.25.0
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/google/go-github/v33 v33.0.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-retryablehttp v0.7.7
@@ -30,7 +31,6 @@ require (
 	github.com/matcornic/hermes/v2 v2.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nats-io/jwt/v2 v2.7.3
 	github.com/nats-io/nats-server/v2 v2.10.26
 	github.com/nats-io/nats.go v1.39.1
@@ -44,7 +44,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/jwalterweatherman v1.1.0
-	github.com/spf13/viper v1.19.0
+	github.com/spf13/viper v1.20.0
 	github.com/ugorji/go/codec v1.2.12
 	github.com/ulikunitz/xz v0.5.12
 	github.com/vbauerster/mpb/v8 v8.9.3
@@ -117,7 +117,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -133,7 +132,6 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/magiconair/properties v1.8.9 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
@@ -156,12 +154,11 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sagikazarmark/locafero v0.7.0 // indirect
-	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/sagikazarmark/locafero v0.8.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
-	github.com/spf13/afero v1.12.0 // indirect
+	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
@@ -176,10 +173,8 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.15.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.31.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
 )

--- a/network/protocol/model.go
+++ b/network/protocol/model.go
@@ -31,7 +31,7 @@ import (
 	"reflect"
 	"strings"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 func (n NetworkProtocol) String() string {

--- a/size/model.go
+++ b/size/model.go
@@ -32,7 +32,7 @@ import (
 	"math"
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 func (s Size) Code(unit rune) string {

--- a/status/control/model.go
+++ b/status/control/model.go
@@ -30,7 +30,7 @@ import (
 	"reflect"
 	"strings"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 )
 
 func (c Mode) String() string {

--- a/viper/hook.go
+++ b/viper/hook.go
@@ -31,7 +31,7 @@ import (
 	"math"
 	"reflect"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 	spfvpr "github.com/spf13/viper"
 )
 

--- a/viper/interface.go
+++ b/viper/interface.go
@@ -33,7 +33,7 @@ import (
 
 	liblog "github.com/nabbar/golib/logger"
 
-	libmap "github.com/mitchellh/mapstructure"
+	libmap "github.com/go-viper/mapstructure/v2"
 	libctx "github.com/nabbar/golib/context"
 	liberr "github.com/nabbar/golib/errors"
 	loglvl "github.com/nabbar/golib/logger/level"


### PR DESCRIPTION
## Type of Change
- [ ] Fixes an issue
- [ ] Adds a new feature
- [ ] Refactor
- [ ] Documentation update
- [X] Other (please describe it in the Description Section)

## Description
- Update `mapstructure` dependencie from `github.com/mitchellh/mapstructure` to `github.com/go-viper/mapstructure/v2`

